### PR TITLE
Add Wine to the PATH if it's bundled in

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -376,6 +376,12 @@ export namespace GameLauncher {
         ...newEnvVars, 'WINEDEBUG': 'fixme-all',
         ...(proxy !== '' ? {'http_proxy': `http://${proxy}/`, 'HTTP_PROXY': `http://${proxy}/`} : null)
       };
+      // If WINE's bin directory exists in FPSoftware, add it to the PATH
+      if (fs.existsSync(`${fpPath}/FPSoftware/Wine/bin`)) {
+        newEnvVars = {
+          ...newEnvVars, 'PATH': `${fpPath}/FPSoftware/Wine/bin:` + process.env.PATH
+        }
+      }
     }
     return {
       // Copy this processes environment variables


### PR DESCRIPTION
On Mac & Linux systems, check if Wine is bundled in at `FPSoftware/Wine/bin`. If the directory exists, add it to the PATH.